### PR TITLE
feat(diff): use git diff so we can exclude *.lock files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Calculation:
 Total lines changed = lines added + lines deleted
 ```
 
+Note that as of v2 this action will exclude any .lock files from the above count. If you want to include *.lock files in your count you should use v1.1.
+
 ## Inputs
 
 | Name                | Description                                                                                                           | Required | Default |
@@ -34,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: maidsafe/pr_size_checker@v1.1
+      - uses: maidsafe/pr_size_checker@v2
         with:
           max_lines_changed: 200
 ```

--- a/action.yml
+++ b/action.yml
@@ -12,22 +12,19 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - run: |
-        additions=${{ github.event.pull_request.additions }}
-        echo "additions=${additions}" >> $GITHUB_ENV
-        deletions=${{ github.event.pull_request.deletions }}
-        echo "deletions=${deletions}" >> $GITHUB_ENV
-        echo "Additions: "
-        echo $additions
-        echo "Deletions: "
-        echo $deletions
-      shell: bash
     - id: get_total_lines_changed
       run: |
-        size=$(($additions + $deletions))
+        size=$(git diff --stat origin/master \
+        | grep -v .lock \
+        | awk -F"|" '{ print $2 }' \
+        | awk '{ print $1 }' \
+        | sed '/^$/d' \
+        | paste -sd+ - \
+        | bc)
+
         echo "size=${size}" >> $GITHUB_ENV
         echo ""
-        echo "Total lines changed: "
+        echo "Total lines changed (note: *.lock files are excluded from this count): "
         echo $size
       shell: bash
     - run: |


### PR DESCRIPTION
Using `git diff` instead of the API response means that we can exclude particular file types - all *.lock files are now excluded.