### PR TITLE
fix: Compare with origin/HEAD to support different default branches

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Maximum number of lines changed allowed'
     required: true
     default: '200'
+  target_branch:
+    description: The branch to compare against
+    required: true
+    default: master
 outputs:
   total_lines_changed:
     description: 'Total lines changed in this PR'
@@ -14,7 +18,7 @@ runs:
   steps:
     - id: get_total_lines_changed
       run: |
-        size=$(git diff --stat origin/master \
+        size=$(git diff --stat origin/${{ inputs.target_branch }} \
         | grep -v .lock \
         | awk -F"|" '{ print $2 }' \
         | awk '{ print $1 }' \


### PR DESCRIPTION
- 0daeb8f **fix: Make upstream branch for comparison configurable**

  Not all repositories use `master` – in fact repositories initialised
  in GitHub will now default to `main`.
