### PR TITLE
feat!: Use main as the default target branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   target_branch:
     description: The branch to compare against
     required: true
-    default: master
+    default: main
 outputs:
   total_lines_changed:
     description: 'Total lines changed in this PR'


### PR DESCRIPTION
- 017b1d8 **feat!: Use main as the default target branch**

  This will be better for future compatibility as more repositories
  migrate to `main` as the default branch.
  
  BREAKING CHANGE: Repository's using `master` as the default branch will
  have to explicitly set `default_branch: master` in their inputs.
