### PR TITLE
fix: ignore binary files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,7 @@ runs:
       run: |
         size=$(git diff --stat origin/${{ inputs.target_branch }} \
         | grep -v .lock \
+        | grep -v Bin \
         | awk -F"|" '{ print $2 }' \
         | awk '{ print $1 }' \
         | sed '/^$/d' \


### PR DESCRIPTION
When there are binary files in the PR, the action currently calculates file size as 0 becase `bc` shows an error.

This change ignores binary file changes.